### PR TITLE
33 fix project path to 29 redo global calcs

### DIFF
--- a/app/OPR.py
+++ b/app/OPR.py
@@ -132,7 +132,7 @@ def loadTeamNumbers() -> list:
     """
     Loads teams from a csv file team_list_filtered.csv (created in jsonparse.py)
     """
-    return list(pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","team_list_filtered.csv"))["teamNumber"])
+    return list(pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","team_list_filtered.csv"))["teamNumber"])
 
 
 def filterMatchesByTeams(matches, teams: list):
@@ -149,13 +149,13 @@ def filterMatchesByTeams(matches, teams: list):
 def loadMatches(filter_by_teams: list = []):
     """
     Returns a pandas object of the all_matches.csv file containing all matches.
-    \nRelies on generatedfiles/all_matches.csv
+    \nRelies on app/generatedfiles/all_matches.csv
     \nParameters:
     \n\t filter_by_teams (list) - Filters the matches only including the team numbers in the list
     
     """
     #TODO: Update everything else that relies on this function's output to accomodate pandas
-    all_matches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","all_matches.csv")) # Get the csv data
+    all_matches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_matches.csv")) # Get the csv data
 
     # Make the start time column use the datetime format
     all_matches["actualStartTime"] = pd.to_datetime(all_matches["actualStartTime"], format="mixed")
@@ -246,7 +246,7 @@ def build_m(load_m: bool, matches: pd.DataFrame, teams: list) -> numpy.matrix:
         if (DEBUG_LEVEL>1):
             print(info_i()+" [OPRv4][build_m]  Loading matrix from file, not building it.")
             
-        M = numpy.load(os.path.join(PATH_TO_FTCAPI,"generatedfiles","OPR-m.npy"))
+        M = numpy.load(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","OPR-m.npy"))
 
         if DEBUG_LEVEL>1:
             print(green_check()+" [OPRv4][build_m]  Matrix M successfully loaded from file OPR-m.npy")
@@ -309,15 +309,15 @@ def build_m(load_m: bool, matches: pd.DataFrame, teams: list) -> numpy.matrix:
         
 
         # save the matrix to a file for later loading
-        numpy.save(os.path.join(PATH_TO_FTCAPI,"generatedfiles","OPR-m"),M)
+        numpy.save(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","OPR-m"),M)
 
     if (DEBUG_LEVEL>2):
         print(info_i()+"  M:")
         print(M)
         print()
         if (DEBUG_LEVEL>3):
-            print(info_i()+"  Saving M to generatedfiles/M_debug.csv for debug purposes... (this could take a little bit if it is big)")
-            numpy.savetxt(os.path.join(PATH_TO_FTCAPI,"generatedfiles","M_debug.csv"), M, delimiter=",")
+            print(info_i()+"  Saving M to app/generatedfiles/M_debug.csv for debug purposes... (this could take a little bit if it is big)")
+            numpy.savetxt(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","M_debug.csv"), M, delimiter=",")
             print(green_check()+"  Saved.")
 
     return M
@@ -724,7 +724,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches=matches,
             teams=teams, 
-            output_file_path=os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_global_result_sorted.csv"),  
+            output_file_path=os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_global_result_sorted.csv"),  
             load_m=False
         )
 
@@ -760,7 +760,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches=matches,
             teams=teams,
-            output_file_path=os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_result_sorted.csv"),  
+            output_file_path=os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_result_sorted.csv"),  
             load_m=False
         )
 
@@ -800,7 +800,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches=matches,
             teams=teams,
-            output_file_path=os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_recent_result_sorted.csv"), 
+            output_file_path=os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_recent_result_sorted.csv"), 
             load_m=False,
             fallback="zeroes"
         )
@@ -840,7 +840,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches = matches,
             teams=teams,
-            output_file_path = os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_event_result_sorted.csv"),  
+            output_file_path = os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_event_result_sorted.csv"),  
             load_m  = False
         )
 

--- a/app/OPR.py
+++ b/app/OPR.py
@@ -59,7 +59,7 @@ import os
 
 # Internal Imports
 import json_parse
-from common_resources import PATH_TO_FTCAPI, NUMBER_OF_DAYS_FOR_RECENT_OPR, EVENT_CODE, PATH_TO_JOBLIB_CACHE, DO_JOBLIB_MEMORY
+from common_resources import PROJECT_PATH, NUMBER_OF_DAYS_FOR_RECENT_OPR, EVENT_CODE, PATH_TO_JOBLIB_CACHE, DO_JOBLIB_MEMORY
 from common_resources import DEBUG_LEVEL, FIELD_MODE
 from common_resources import log_error, green_check, info_i, red_x, byte_to_gb, seconds_to_time
 
@@ -132,7 +132,7 @@ def loadTeamNumbers() -> list:
     """
     Loads teams from a csv file team_list_filtered.csv (created in jsonparse.py)
     """
-    return list(pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","team_list_filtered.csv"))["teamNumber"])
+    return list(pd.read_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","team_list_filtered.csv"))["teamNumber"])
 
 
 def filterMatchesByTeams(matches, teams: list):
@@ -155,7 +155,7 @@ def loadMatches(filter_by_teams: list = []):
     
     """
     #TODO: Update everything else that relies on this function's output to accomodate pandas
-    all_matches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_matches.csv")) # Get the csv data
+    all_matches = pd.read_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","all_matches.csv")) # Get the csv data
 
     # Make the start time column use the datetime format
     all_matches["actualStartTime"] = pd.to_datetime(all_matches["actualStartTime"], format="mixed")
@@ -246,7 +246,7 @@ def build_m(load_m: bool, matches: pd.DataFrame, teams: list) -> numpy.matrix:
         if (DEBUG_LEVEL>1):
             print(info_i()+" [OPRv4][build_m]  Loading matrix from file, not building it.")
             
-        M = numpy.load(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","OPR-m.npy"))
+        M = numpy.load(os.path.join(PROJECT_PATH,"app","generatedfiles","OPR-m.npy"))
 
         if DEBUG_LEVEL>1:
             print(green_check()+" [OPRv4][build_m]  Matrix M successfully loaded from file OPR-m.npy")
@@ -309,7 +309,7 @@ def build_m(load_m: bool, matches: pd.DataFrame, teams: list) -> numpy.matrix:
         
 
         # save the matrix to a file for later loading
-        numpy.save(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","OPR-m"),M)
+        numpy.save(os.path.join(PROJECT_PATH,"app","generatedfiles","OPR-m"),M)
 
     if (DEBUG_LEVEL>2):
         print(info_i()+"  M:")
@@ -317,7 +317,7 @@ def build_m(load_m: bool, matches: pd.DataFrame, teams: list) -> numpy.matrix:
         print()
         if (DEBUG_LEVEL>3):
             print(info_i()+"  Saving M to app/generatedfiles/M_debug.csv for debug purposes... (this could take a little bit if it is big)")
-            numpy.savetxt(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","M_debug.csv"), M, delimiter=",")
+            numpy.savetxt(os.path.join(PROJECT_PATH,"app","generatedfiles","M_debug.csv"), M, delimiter=",")
             print(green_check()+"  Saved.")
 
     return M
@@ -724,7 +724,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches=matches,
             teams=teams, 
-            output_file_path=os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_global_result_sorted.csv"),  
+            output_file_path=os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_global_result_sorted.csv"),  
             load_m=False
         )
 
@@ -760,7 +760,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches=matches,
             teams=teams,
-            output_file_path=os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_result_sorted.csv"),  
+            output_file_path=os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_result_sorted.csv"),  
             load_m=False
         )
 
@@ -800,7 +800,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches=matches,
             teams=teams,
-            output_file_path=os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_recent_result_sorted.csv"), 
+            output_file_path=os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_recent_result_sorted.csv"), 
             load_m=False,
             fallback="zeroes"
         )
@@ -840,7 +840,7 @@ def master_function(memory=memory):
         do_all_opr_stuff(
             matches = matches,
             teams=teams,
-            output_file_path = os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_event_result_sorted.csv"),  
+            output_file_path = os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_event_result_sorted.csv"),  
             load_m  = False
         )
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -55,7 +55,7 @@ import requests
 from dotenv import load_dotenv
 
 # Local Imports
-from common_resources import PATH_TO_FTCAPI, EVENT_CODE, SEASON_YEAR, log_error, green_check, red_x, info_i
+from common_resources import PROJECT_PATH, EVENT_CODE, SEASON_YEAR, log_error, green_check, red_x, info_i
 from common_resources import DEBUG_LEVEL, __version__
 import sheets_api
 
@@ -133,7 +133,7 @@ def save_response(response:requests.Response, path):
         log_error(f"[__main__] save_response was unable to get the json of a response (saving to path {path})")
         raise e
     
-    with open(os.path.join(PATH_TO_FTCAPI,path),"w") as writer:
+    with open(os.path.join(PROJECT_PATH,path),"w") as writer:
         json.dump(data, writer, indent=4)
 
 def get_matches ():

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -145,7 +145,7 @@ def get_matches ():
         headers=AUTHORIZATION_HEADER
     )
 
-    save_response(response, "generatedfiles/eventdata/event_matches.json")
+    save_response(response, "app/generatedfiles/eventdata/event_matches.json")
 
 
     # Get the teams for the event
@@ -154,7 +154,7 @@ def get_matches ():
         headers=AUTHORIZATION_HEADER
     )
 
-    save_response(response, "generatedfiles/eventdata/event_teams.json")
+    save_response(response, "app/generatedfiles/eventdata/event_teams.json")
 
 
     # Get the event as a whole and put it into opr/all_events/EVENTCODE (needed for event-only OPR calculation)
@@ -163,7 +163,7 @@ def get_matches ():
         headers=AUTHORIZATION_HEADER
     )
 
-    save_response(response, f"generatedfiles/opr/all_events/{EVENT_CODE.replace('/','_')}.json")
+    save_response(response, f"app/generatedfiles/opr/all_events/{EVENT_CODE.replace('/','_')}.json")
     
 
 
@@ -174,7 +174,7 @@ def get_rankings():
         headers=AUTHORIZATION_HEADER
     )
 
-    save_response(response, f"generatedfiles/eventdata/event_rankings.json")
+    save_response(response, f"app/generatedfiles/eventdata/event_rankings.json")
     
 
 
@@ -186,7 +186,7 @@ def get_schedule():
         headers=AUTHORIZATION_HEADER
     )
 
-    save_response(response, f"generatedfiles/eventdata/eventschedule_qual.json")
+    save_response(response, f"app/generatedfiles/eventdata/eventschedule_qual.json")
 
     # Playoffs
     response = requests.get(
@@ -194,7 +194,7 @@ def get_schedule():
         headers=AUTHORIZATION_HEADER
     )
 
-    save_response(response, f"generatedfiles/eventdata/eventschedule_playoff.json")
+    save_response(response, f"app/generatedfiles/eventdata/eventschedule_playoff.json")
 
 
 

--- a/app/common_resources.py
+++ b/app/common_resources.py
@@ -64,20 +64,23 @@ load_dotenv() # Load the environment variables
 
 
 # Environment Variables
-PATH_TO_FTCAPI = os.getenv("PROJECT_PATH", None) # The absolute path to the "app" directory within this project.
+default_path = os.path.split(os.path.split(os.path.abspath(__file__))[0])[0] # The absolute path to the dir two levels above (should be project dir).
+PATH_TO_FTCAPI = os.getenv("PROJECT_PATH", default_path) # The absolute path to the project directory.
+del default_path
+
 DEBUG_LEVEL = int(os.getenv("DEBUG_LEVEL", 0))
 EVENT_CODE = os.getenv("EVENT_CODE", "FTCCMP1FRAN")
 FIELD_MODE = os.getenv("FIELD_MODE", None) #TODO: Determine if this is necessary
 SEASON_YEAR = int(os.getenv("SEASON_YEAR",2023))
 
 # Google Sheets stuff
-SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_KEY_PATH", PATH_TO_FTCAPI[:-4] + "ServiceAccountKey.json") # Used in sheetsapi (the -4 removes the "/app" from the path to ftcapi)
+SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_KEY_PATH", PATH_TO_FTCAPI + "ServiceAccountKey.json") # Used in sheetsapi
 SPREADSHEET_ID = os.getenv("GOOGLE_SPREADSHEET_ID", "<placeholder Google Sheets Spreadsheet ID>") # https://docs.google.com/spreadsheets/d/SPREADSHEET_ID_HERE/edit
 
 
 #region Joblib
 DO_JOBLIB_MEMORY = os.getenv("DO_JOBLIB_MEMORY", "True").lower() == "true"  # Used to be True
-PATH_TO_JOBLIB_CACHE = os.getenv("JOBLIB_PATH", os.path.join(PATH_TO_FTCAPI,"generatedfiles","joblibcache","joblib"))
+PATH_TO_JOBLIB_CACHE = os.getenv("JOBLIB_PATH", os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","joblibcache","joblib"))
 
 # The following code was copied and modified from viniciusarrud on GitHub https://github.com/joblib/joblib/issues/1496#issuecomment-1788968714
 # It is a fix for a bug in Windows where it throws errors if you try to access a path longer than ~250 chars.
@@ -186,7 +189,7 @@ def log_error(message: str, level="ERROR") -> None:
     """
     Logs an error message (with timestamp) to the error log at PATH_TO_FTCAPI/errors.log
     """
-    with open(os.path.join(PATH_TO_FTCAPI,"generatedfiles","errors.log"), "a") as myfile:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","errors.log"), "a") as myfile:
         myfile.write(f"[{datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')}][{level}!] "+str(message)+"\n")
 
 

--- a/app/common_resources.py
+++ b/app/common_resources.py
@@ -46,7 +46,7 @@ EDrewcated Guesser. If not, see <https://www.gnu.org/licenses/>.
 __all__ = [
     "get_json", "log_error", "byte_to_gb", "seconds_to_time", 
     "NUMBER_OF_DAYS_FOR_RECENT_OPR", "DO_JOBLIB_MEMORY", 
-    "PATH_TO_FTCAPI", "PATH_TO_JOBLIB_MEMORY", "SERVICE_ACCOUNT_FILE", 
+    "PROJECT_PATH", "PATH_TO_JOBLIB_MEMORY", "SERVICE_ACCOUNT_FILE", 
     "SPREADSHEET_ID"
 ]
 __version__ = "49.1 Beta"
@@ -65,7 +65,7 @@ load_dotenv() # Load the environment variables
 
 # Environment Variables
 default_path = os.path.split(os.path.split(os.path.abspath(__file__))[0])[0] # The absolute path to the dir two levels above (should be project dir).
-PATH_TO_FTCAPI = os.getenv("PROJECT_PATH", default_path) # The absolute path to the project directory.
+PROJECT_PATH = os.getenv("PROJECT_PATH", default_path) # The absolute path to the project directory.
 del default_path
 
 DEBUG_LEVEL = int(os.getenv("DEBUG_LEVEL", 0))
@@ -74,13 +74,13 @@ FIELD_MODE = os.getenv("FIELD_MODE", None) #TODO: Determine if this is necessary
 SEASON_YEAR = int(os.getenv("SEASON_YEAR",2023))
 
 # Google Sheets stuff
-SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_KEY_PATH", PATH_TO_FTCAPI + "ServiceAccountKey.json") # Used in sheetsapi
+SERVICE_ACCOUNT_FILE = os.getenv("SERVICE_ACCOUNT_KEY_PATH", PROJECT_PATH + "ServiceAccountKey.json") # Used in sheetsapi
 SPREADSHEET_ID = os.getenv("GOOGLE_SPREADSHEET_ID", "<placeholder Google Sheets Spreadsheet ID>") # https://docs.google.com/spreadsheets/d/SPREADSHEET_ID_HERE/edit
 
 
 #region Joblib
 DO_JOBLIB_MEMORY = os.getenv("DO_JOBLIB_MEMORY", "True").lower() == "true"  # Used to be True
-PATH_TO_JOBLIB_CACHE = os.getenv("JOBLIB_PATH", os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","joblibcache","joblib"))
+PATH_TO_JOBLIB_CACHE = os.getenv("JOBLIB_PATH", os.path.join(PROJECT_PATH,"app","generatedfiles","joblibcache","joblib"))
 
 # The following code was copied and modified from viniciusarrud on GitHub https://github.com/joblib/joblib/issues/1496#issuecomment-1788968714
 # It is a fix for a bug in Windows where it throws errors if you try to access a path longer than ~250 chars.
@@ -187,9 +187,9 @@ def byte_to_gb(bytes) -> float:
 
 def log_error(message: str, level="ERROR") -> None:
     """
-    Logs an error message (with timestamp) to the error log at PATH_TO_FTCAPI/errors.log
+    Logs an error message (with timestamp) to the error log at PROJECT_PATH/errors.log
     """
-    with open(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","errors.log"), "a") as myfile:
+    with open(os.path.join(PROJECT_PATH,"app","generatedfiles","errors.log"), "a") as myfile:
         myfile.write(f"[{datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')}][{level}!] "+str(message)+"\n")
 
 
@@ -220,7 +220,7 @@ if __name__ == "__main__":
     a = {
         "NUMBER_OF_DAYS_FOR_RECENT_OPR" : NUMBER_OF_DAYS_FOR_RECENT_OPR,
         "EVENTCODE"       : EVENT_CODE,
-        "PATH_TO_FTCAPI"  : PATH_TO_FTCAPI,
+        "PROJECT_PATH"  : PROJECT_PATH,
         "CRAPPY_LAPTOP"   : CRAPPY_LAPTOP,
         "DO_JOBLIB_MEMORY": DO_JOBLIB_MEMORY,
         "PATH_TO_JOBLIB_CACHE"  : PATH_TO_JOBLIB_CACHE,

--- a/app/json_parse.py
+++ b/app/json_parse.py
@@ -48,7 +48,7 @@ of functions, the most used being preparing for OPR calculation.
 import sys
 import os
 
-from common_resources import log_error, green_check, info_i, red_x, get_json, PATH_TO_FTCAPI, accepted_match_types
+from common_resources import log_error, green_check, info_i, red_x, get_json, PROJECT_PATH, accepted_match_types
 from common_resources import DEBUG_LEVEL
 
 try:
@@ -73,7 +73,7 @@ def get_team_stats(team_number) -> dict:
     if DEBUG_LEVEL>1:
         print(info_i()+f"         [jsonparse.py][get_team_stats] Getting team stats for team #{team_number}")
     
-    all_oprs = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_result_sorted.csv"), index_col=False)
+    all_oprs = pd.read_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_result_sorted.csv"), index_col=False)
 
     try:
         team_stats["OPR"]     = all_oprs[all_oprs["Team"]==team_number]["OPR"].values[0]
@@ -93,7 +93,7 @@ def get_team_stats(team_number) -> dict:
         team_stats["CCWM"]    = 1
     #Team,OPR,AutoOPR,CCWM
 
-    all_oprs_recent = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_recent_result_sorted.csv"), index_col=False)
+    all_oprs_recent = pd.read_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_recent_result_sorted.csv"), index_col=False)
 
     try:
         team_stats["recentOPR"]     = all_oprs_recent.loc[all_oprs_recent["Team"]==team_number]["OPR"].values[0]
@@ -652,11 +652,11 @@ def write_needed_events(season_events, texasonly=False):
     """
     print(info_i()+" Writing needed events...")
     
-    rawevents = open(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","needed_events_raw.json"),"w+")
+    rawevents = open(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","needed_events_raw.json"),"w+")
     rawevents.truncate()
     rawevents.write('{"matches":[\n')
     
-    with open(os.path.join(PATH_TO_FTCAPI+"app","generatedfiles","opr","needed-event-ids.txt"),"w+") as thefile:
+    with open(os.path.join(PROJECT_PATH+"app","generatedfiles","opr","needed-event-ids.txt"),"w+") as thefile:
         thefile.truncate() # Clear the file
         filtered_event_list = season_events.filter(type=accepted_match_types, state=("TX" if texasonly else None))
         # Iterate over every event
@@ -681,9 +681,9 @@ def write_needed_teams(use_opr=False):
     counter  = 0
     eventcounter = 0
     if (not use_opr):
-        thepath = os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_events")
+        thepath = os.path.join(PROJECT_PATH,"app","generatedfiles","all_events")
     else:
-        thepath = os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events")
+        thepath = os.path.join(PROJECT_PATH,"app","generatedfiles","opr","all_events")
     
     l=len(os.listdir(thepath))
 
@@ -712,7 +712,7 @@ def write_needed_teams(use_opr=False):
     
     print(green_check()+"    Teams assembled. Writing all teams to file team-ids-to-get.txt...       ")
     
-    with open(os.path.join(PATH_TO_FTCAPI,"app/generatedfiles",("opr","all-teamids-involved.txt" if use_opr else "team-ids-to-get.txt")),"w+") as thefile:
+    with open(os.path.join(PROJECT_PATH,"app/generatedfiles",("opr","all-teamids-involved.txt" if use_opr else "team-ids-to-get.txt")),"w+") as thefile:
         thefile.truncate() # Clear the file
         for team in allteams:
             thefile.write(str(team)+"\n")
@@ -726,7 +726,7 @@ def loadMatches(filter_by_teams=None) -> pd.DataFrame:
     Returns a pandas object of the csv file containing all matches (reads from all_matches.csv, created by prepare_opr_calculation)
     """
     #TODO: update everything else that relies on this function's output to accomodate pandas
-    all_matches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_matches.csv"))
+    all_matches = pd.read_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","all_matches.csv"))
     all_matches["actualStartTime"] = pd.to_datetime(all_matches["actualStartTime"], "format=mixed")#format="%Y-%m-%"+"dT%H:%M:%S.%"+"f")
 
     # if filter_by_teams isn't none, filter the matches
@@ -764,7 +764,7 @@ def prepare_opr_calculation(
     try:
         l=len(os.listdir(
             (
-                os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events"))
+                os.path.join(PROJECT_PATH,"app","generatedfiles","opr","all_events"))
             ))
     except FileNotFoundError as e:
         log_error("[json_parse.py][prepare_opr_calculation] app/generatedfiles/opr/all_events directory does not exist!",level="WARNING")
@@ -795,19 +795,19 @@ def prepare_opr_calculation(
         print(info_i()+"    [prepare_opr_calculation] Getting teams...")
     
     if specific_event==None:
-        path_list = [ os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events", j) for j in [i for i in os.listdir(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events"))]]
+        path_list = [ os.path.join(PROJECT_PATH,"app","generatedfiles","opr","all_events", j) for j in [i for i in os.listdir(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","all_events"))]]
 
     elif specific_event=="RECENT":
         if DEBUG_LEVEL>0:
             # event_matches.json is updated in ftcapiv3.sh, during the getmatches
             print(info_i() + "    [prepare_opr_calculation] Iterating through only event in event_matches.json")
-        path_list = [os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_matches.json")]
+        path_list = [os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_matches.json")]
         l = 1
     
     else:
         if DEBUG_LEVEL>0:
             print(info_i() + "    [prepare_opr_calculation] Iterating through only one event with code "+str(specific_event))
-        path_list = [os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events",str(specific_event).upper()+".json")]
+        path_list = [os.path.join(PROJECT_PATH,"app","generatedfiles","opr","all_events",str(specific_event).upper()+".json")]
         l = 1
 
     
@@ -875,7 +875,7 @@ def prepare_opr_calculation(
     if (specific_event_teams != None):
         try:
             # If the current event is the specific event given, add all teams to list
-            event_teams_raw_json = get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_teams.json")) # Created when FTC APIing
+            event_teams_raw_json = get_json(os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_teams.json")) # Created when FTC APIing
 
             #print("event_teams_raw_json[teams]"+str(event_teams_raw_json["teams"]))
     
@@ -933,13 +933,13 @@ def prepare_opr_calculation(
     if DEBUG_LEVEL>1:
         print(green_check()+"    Teams assembled. Writing all matches per team to file app/generatedfiles/matches_per_team.csv...       ") #TODO: Replace with actual path from os.join
     
-    matches_per_team.to_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","matches_per_team.csv"), index=False)
+    matches_per_team.to_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","matches_per_team.csv"), index=False)
 
 
     if DEBUG_LEVEL>1:
         print(green_check()+"    Teams assembled. Writing all team numbers to file app/generatedfiles/team_list_filtered.csv...       ")
     
-    matches_per_team["teamNumber"].to_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","team_list_filtered.csv"), index=False)
+    matches_per_team["teamNumber"].to_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","team_list_filtered.csv"), index=False)
 
     
 
@@ -969,7 +969,7 @@ def prepare_opr_calculation(
     if DEBUG_LEVEL>0:
         print(green_check()+"    Matches assembled. Writing all teams to file app/generatedfiles/all_matches.csv...       ")
     
-    all_matches_pd.to_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_matches.csv"), index=False)
+    all_matches_pd.to_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","all_matches.csv"), index=False)
 
     if DEBUG_LEVEL>2:
         print(green_check()+f"    Wrote about {len(pd.unique(all_matches_pd['Red1']))} (unique in Red1) of teams out of {matchcounter} matches (matchcounter).")
@@ -983,9 +983,9 @@ def prepare_opr_calculation(
 if __name__ == "__main__" and "get-events-global" in sys.argv:
     print(info_i()+"  [jsonparse.py] This script was called as __main__")
     print(info_i()+"      Jsonparse getting global event ids that match")
-    print(info_i()+"      Getting the season\'s data from seasondata at "+os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","season_data.json"))
+    print(info_i()+"      Getting the season\'s data from seasondata at "+os.path.join(PROJECT_PATH,"app","generatedfiles","season_data.json"))
 
-    write_needed_events(SeasonEvents(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","season_data.json"))), texasonly=False)
+    write_needed_events(SeasonEvents(get_json(os.path.join(PROJECT_PATH,"app","generatedfiles","season_data.json"))), texasonly=False)
 
 
 # -- End of file --

--- a/app/json_parse.py
+++ b/app/json_parse.py
@@ -73,7 +73,7 @@ def get_team_stats(team_number) -> dict:
     if DEBUG_LEVEL>1:
         print(info_i()+f"         [jsonparse.py][get_team_stats] Getting team stats for team #{team_number}")
     
-    all_oprs = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_result_sorted.csv"), index_col=False)
+    all_oprs = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_result_sorted.csv"), index_col=False)
 
     try:
         team_stats["OPR"]     = all_oprs[all_oprs["Team"]==team_number]["OPR"].values[0]
@@ -93,7 +93,7 @@ def get_team_stats(team_number) -> dict:
         team_stats["CCWM"]    = 1
     #Team,OPR,AutoOPR,CCWM
 
-    all_oprs_recent = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_recent_result_sorted.csv"), index_col=False)
+    all_oprs_recent = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_recent_result_sorted.csv"), index_col=False)
 
     try:
         team_stats["recentOPR"]     = all_oprs_recent.loc[all_oprs_recent["Team"]==team_number]["OPR"].values[0]
@@ -652,11 +652,11 @@ def write_needed_events(season_events, texasonly=False):
     """
     print(info_i()+" Writing needed events...")
     
-    rawevents = open(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","needed_events_raw.json"),"w+")
+    rawevents = open(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","needed_events_raw.json"),"w+")
     rawevents.truncate()
     rawevents.write('{"matches":[\n')
     
-    with open(os.path.join(PATH_TO_FTCAPI+f"generatedfiles","opr","needed-event-ids.txt"),"w+") as thefile:
+    with open(os.path.join(PATH_TO_FTCAPI+"app","generatedfiles","opr","needed-event-ids.txt"),"w+") as thefile:
         thefile.truncate() # Clear the file
         filtered_event_list = season_events.filter(type=accepted_match_types, state=("TX" if texasonly else None))
         # Iterate over every event
@@ -681,9 +681,9 @@ def write_needed_teams(use_opr=False):
     counter  = 0
     eventcounter = 0
     if (not use_opr):
-        thepath = os.path.join(PATH_TO_FTCAPI,"generatedfiles","all_events")
+        thepath = os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_events")
     else:
-        thepath = os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","all_events")
+        thepath = os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events")
     
     l=len(os.listdir(thepath))
 
@@ -712,7 +712,7 @@ def write_needed_teams(use_opr=False):
     
     print(green_check()+"    Teams assembled. Writing all teams to file team-ids-to-get.txt...       ")
     
-    with open(os.path.join(PATH_TO_FTCAPI,"generatedfiles",("opr","all-teamids-involved.txt" if use_opr else "generatedfiles","team-ids-to-get.txt")),"w+") as thefile:
+    with open(os.path.join(PATH_TO_FTCAPI,"app/generatedfiles",("opr","all-teamids-involved.txt" if use_opr else "team-ids-to-get.txt")),"w+") as thefile:
         thefile.truncate() # Clear the file
         for team in allteams:
             thefile.write(str(team)+"\n")
@@ -726,7 +726,7 @@ def loadMatches(filter_by_teams=None) -> pd.DataFrame:
     Returns a pandas object of the csv file containing all matches (reads from all_matches.csv, created by prepare_opr_calculation)
     """
     #TODO: update everything else that relies on this function's output to accomodate pandas
-    all_matches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","all_matches.csv"))
+    all_matches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_matches.csv"))
     all_matches["actualStartTime"] = pd.to_datetime(all_matches["actualStartTime"], "format=mixed")#format="%Y-%m-%"+"dT%H:%M:%S.%"+"f")
 
     # if filter_by_teams isn't none, filter the matches
@@ -764,11 +764,11 @@ def prepare_opr_calculation(
     try:
         l=len(os.listdir(
             (
-                os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","all_events"))
+                os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events"))
             ))
     except FileNotFoundError as e:
-        log_error("[json_parse.py][prepare_opr_calculation] generatedfiles/opr/all_events directory does not exist!",level="WARNING")
-        print(red_x()+"Warning: generatedfiles/opr/all_events directory does not exist.")
+        log_error("[json_parse.py][prepare_opr_calculation] app/generatedfiles/opr/all_events directory does not exist!",level="WARNING")
+        print(red_x()+"Warning: app/generatedfiles/opr/all_events directory does not exist.")
 
     matches_per_team_dic = {}
     all_matches_dic = {
@@ -795,19 +795,19 @@ def prepare_opr_calculation(
         print(info_i()+"    [prepare_opr_calculation] Getting teams...")
     
     if specific_event==None:
-        path_list = [ os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","all_events", j) for j in [i for i in os.listdir(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","all_events"))]]
+        path_list = [ os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events", j) for j in [i for i in os.listdir(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events"))]]
 
     elif specific_event=="RECENT":
         if DEBUG_LEVEL>0:
             # event_matches.json is updated in ftcapiv3.sh, during the getmatches
             print(info_i() + "    [prepare_opr_calculation] Iterating through only event in event_matches.json")
-        path_list = [os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_matches.json")]
+        path_list = [os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_matches.json")]
         l = 1
     
     else:
         if DEBUG_LEVEL>0:
             print(info_i() + "    [prepare_opr_calculation] Iterating through only one event with code "+str(specific_event))
-        path_list = [os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","all_events",str(specific_event).upper()+".json")]
+        path_list = [os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","all_events",str(specific_event).upper()+".json")]
         l = 1
 
     
@@ -875,7 +875,7 @@ def prepare_opr_calculation(
     if (specific_event_teams != None):
         try:
             # If the current event is the specific event given, add all teams to list
-            event_teams_raw_json = get_json(os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_teams.json")) # Created when FTC APIing
+            event_teams_raw_json = get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_teams.json")) # Created when FTC APIing
 
             #print("event_teams_raw_json[teams]"+str(event_teams_raw_json["teams"]))
     
@@ -931,15 +931,15 @@ def prepare_opr_calculation(
     
     #print(matches_per_team)
     if DEBUG_LEVEL>1:
-        print(green_check()+"    Teams assembled. Writing all matches per team to file generatedfiles/matches_per_team.csv...       ") #TODO: Replace with actual path from os.join
+        print(green_check()+"    Teams assembled. Writing all matches per team to file app/generatedfiles/matches_per_team.csv...       ") #TODO: Replace with actual path from os.join
     
-    matches_per_team.to_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","matches_per_team.csv"), index=False)
+    matches_per_team.to_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","matches_per_team.csv"), index=False)
 
 
     if DEBUG_LEVEL>1:
-        print(green_check()+"    Teams assembled. Writing all team numbers to file generatedfiles/team_list_filtered.csv...       ")
+        print(green_check()+"    Teams assembled. Writing all team numbers to file app/generatedfiles/team_list_filtered.csv...       ")
     
-    matches_per_team["teamNumber"].to_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","team_list_filtered.csv"), index=False)
+    matches_per_team["teamNumber"].to_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","team_list_filtered.csv"), index=False)
 
     
 
@@ -967,9 +967,9 @@ def prepare_opr_calculation(
     #print(all_matches_pd)
     
     if DEBUG_LEVEL>0:
-        print(green_check()+"    Matches assembled. Writing all teams to file generatedfiles/all_matches.csv...       ")
+        print(green_check()+"    Matches assembled. Writing all teams to file app/generatedfiles/all_matches.csv...       ")
     
-    all_matches_pd.to_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","all_matches.csv"), index=False)
+    all_matches_pd.to_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","all_matches.csv"), index=False)
 
     if DEBUG_LEVEL>2:
         print(green_check()+f"    Wrote about {len(pd.unique(all_matches_pd['Red1']))} (unique in Red1) of teams out of {matchcounter} matches (matchcounter).")
@@ -983,9 +983,9 @@ def prepare_opr_calculation(
 if __name__ == "__main__" and "get-events-global" in sys.argv:
     print(info_i()+"  [jsonparse.py] This script was called as __main__")
     print(info_i()+"      Jsonparse getting global event ids that match")
-    print(info_i()+"      Getting the season\'s data from seasondata at "+os.path.join(PATH_TO_FTCAPI,"generatedfiles","season_data.json"))
+    print(info_i()+"      Getting the season\'s data from seasondata at "+os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","season_data.json"))
 
-    write_needed_events(SeasonEvents(get_json(os.path.join(PATH_TO_FTCAPI,"generatedfiles","season_data.json"))), texasonly=False)
+    write_needed_events(SeasonEvents(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","season_data.json"))), texasonly=False)
 
 
 # -- End of file --

--- a/app/prepare_machine_learning.py
+++ b/app/prepare_machine_learning.py
@@ -429,9 +429,9 @@ training_data_matches = dataframe_remove_zeroes(training_data_matches, ["redOPR"
 
 if DEBUG_LEVEL>0:
     print(info_i()+f" Training data matches end shape {training_data_matches.shape}")
-    print(info_i()+f" Now saving machine file as {os.path.join(PATH_TO_FTCAPI,"machine_file.csv")}")
+    print(info_i()+f" Now saving machine file as {os.path.join(PATH_TO_FTCAPI,"app","machine_file.csv")}")
 
-training_data_matches.to_csv(os.path.join(PATH_TO_FTCAPI,"machine_file.csv"), index=False)
+training_data_matches.to_csv(os.path.join(PATH_TO_FTCAPI,"app","machine_file.csv"), index=False)
 
 print(green_check()+" Saved to machine_file.csv.")
 #endregion Saving

--- a/app/prepare_machine_learning.py
+++ b/app/prepare_machine_learning.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     print("   [prepare-machinelearning.py] This script was called as __main__")
     print("         Importing...")
 
-from common_resources import PATH_TO_FTCAPI, DO_JOBLIB_MEMORY, NUMBER_OF_DAYS_FOR_RECENT_OPR, get_json, red_x, green_check, info_i, byte_to_gb, seconds_to_time
+from common_resources import PROJECT_PATH, DO_JOBLIB_MEMORY, NUMBER_OF_DAYS_FOR_RECENT_OPR, get_json, red_x, green_check, info_i, byte_to_gb, seconds_to_time
 from common_resources import DEBUG_LEVEL
 
 
@@ -429,9 +429,9 @@ training_data_matches = dataframe_remove_zeroes(training_data_matches, ["redOPR"
 
 if DEBUG_LEVEL>0:
     print(info_i()+f" Training data matches end shape {training_data_matches.shape}")
-    print(info_i()+f" Now saving machine file as {os.path.join(PATH_TO_FTCAPI,"app","machine_file.csv")}")
+    print(info_i()+f" Now saving machine file as {os.path.join(PROJECT_PATH,"app","machine_file.csv")}")
 
-training_data_matches.to_csv(os.path.join(PATH_TO_FTCAPI,"app","machine_file.csv"), index=False)
+training_data_matches.to_csv(os.path.join(PROJECT_PATH,"app","machine_file.csv"), index=False)
 
 print(green_check()+" Saved to machine_file.csv.")
 #endregion Saving

--- a/app/sheets_api.py
+++ b/app/sheets_api.py
@@ -407,15 +407,15 @@ def push_matches(service):
     write_to_range = MATCHES_WRITE_RANGE
 
     # Get the data
-    event_object   = EventMatches(get_json(os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_matches.json")))
-    event_schedule_qual    = EventSchedule(get_json(os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","eventschedule_qual.json")))
-    event_schedule_playoff = EventSchedule(get_json(os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","eventschedule_playoff.json")))
+    event_object   = EventMatches(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_matches.json")))
+    event_schedule_qual    = EventSchedule(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","eventschedule_qual.json")))
+    event_schedule_playoff = EventSchedule(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","eventschedule_playoff.json")))
 
 
-    with open(os.path.join(PATH_TO_FTCAPI,"gsNeigh.pkl"), "rb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"), "rb") as f:
         gsNeigh = pickle.load(f)
     
-    with open(os.path.join(PATH_TO_FTCAPI,"gsSVC.pkl"),"rb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"),"rb") as f:
         gsSVC = pickle.load(f)
     
     predictors = [gsNeigh, gsSVC]
@@ -473,7 +473,7 @@ def push_teams(service):
         print(info_i()+"    Writing season-long OPR data")
         
     write_to_range = TEAMS_WRITE_RANGE
-    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_result_sorted.csv"))
+    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_result_sorted.csv"))
     
     # Add the timestamp to the begining of the data
     data_to_push = add_timestamp(data_to_push.values.tolist())
@@ -495,7 +495,7 @@ def push_teams(service):
         print(info_i()+"    Writing event OPR data")
         
     write_to_range = TEAMS_EVENT_WRITE_RANGE
-    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_event_result_sorted.csv"))
+    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_event_result_sorted.csv"))
     # Add the timestamp to the begining of the data
     data_to_push = add_timestamp(data_to_push.values.tolist())
 
@@ -522,7 +522,7 @@ def push_teams(service):
         print(info_i()+"    Writing recent OPR  data")
         
     write_to_range = TEAMS_RECENT_WRITE_RANGE
-    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"generatedfiles","opr","opr_recent_result_sorted.csv"))
+    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_recent_result_sorted.csv"))
     # Add the timestamp to the begining of the data
     data_to_push = add_timestamp(data_to_push.values.tolist())
 
@@ -554,9 +554,9 @@ def push_rankings(service):
         print(info_i()+" [sheetsapi.py] Pushing rankings data to sheets")
     if DEBUG_LEVEL>1:
         print(info_i()+"    Uses:")
-        print(info_i()+"      -",os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_rankings.json"))
+        print(info_i()+"      -",os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.json"))
         print(info_i()+"    Creates:")
-        print(info_i()+"      -",os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_rankings.csv"))
+        print(info_i()+"      -",os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv"))
         
     #
     # Write event ranking data
@@ -566,7 +566,7 @@ def push_rankings(service):
         
     # from jsonparse, save the rankings dataframe as a csv
     try:
-        rankings_dataframe(os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_rankings.json"),os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_rankings.csv"))
+        rankings_dataframe(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.json"),os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv"))
 
     except IndexError as e:
         log_error(f"[sheetsapi.py][push_rankings] IndexError with rankngs_dataframe in jsonparse. This indicates that eventdata/event_rankings.json is either empty or malformed. This is normal if the event hasn\'t started yet. full error msg: {e}")
@@ -575,7 +575,7 @@ def push_rankings(service):
     write_to_range = TEAMS_RANKING_WRITE_RANGE
     
     try:
-        data_to_push   = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_rankings.csv"))
+        data_to_push   = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv"))
         # Dropping multiple columns with help from 
         # https://stackoverflow.com/questions/13411544/delete-a-column-from-a-pandas-dataframe
         data_to_push.drop(
@@ -589,7 +589,7 @@ def push_rankings(service):
 
     except pd.errors.EmptyDataError:
         # if the file is empty
-        data_to_push = [["No rankings for the given event"],[f'({os.path.join(PATH_TO_FTCAPI,"generatedfiles","eventdata","event_rankings.csv")} is empty)']]
+        data_to_push = [["No rankings for the given event"],[f'({os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv")} is empty)']]
         log_error("[sheetsapi.py][push_rankings] generatedfiles/eventdata/event_rankings.csv is empty. This is normal if an event hasn\'t started yet, but is bad if the rankings are out.",level="Warn")
     
     
@@ -654,10 +654,10 @@ def push_elims_predictions(service):
     if DEBUG_LEVEL>1:
         print(info_i()+" [sheetsapi.py][push_elims_predictions] Elims matches data recieved. Now loading models.")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"gsNeigh.pkl"), "rb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"), "rb") as f:
         gsNeigh = pickle.load(f)
     
-    with open(os.path.join(PATH_TO_FTCAPI,"gsSVC.pkl"),"rb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"),"rb") as f:
         gsSVC = pickle.load(f)
     
     predictors = [gsNeigh, gsSVC]

--- a/app/sheets_api.py
+++ b/app/sheets_api.py
@@ -53,7 +53,7 @@ import pickle
 
 
 # Intraproject imports
-from common_resources import PATH_TO_FTCAPI, SERVICE_ACCOUNT_FILE, SPREADSHEET_ID, log_error
+from common_resources import PROJECT_PATH, SERVICE_ACCOUNT_FILE, SPREADSHEET_ID, log_error
 from common_resources import DEBUG_LEVEL
 
 from json_parse import *
@@ -407,15 +407,15 @@ def push_matches(service):
     write_to_range = MATCHES_WRITE_RANGE
 
     # Get the data
-    event_object   = EventMatches(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_matches.json")))
-    event_schedule_qual    = EventSchedule(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","eventschedule_qual.json")))
-    event_schedule_playoff = EventSchedule(get_json(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","eventschedule_playoff.json")))
+    event_object   = EventMatches(get_json(os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_matches.json")))
+    event_schedule_qual    = EventSchedule(get_json(os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","eventschedule_qual.json")))
+    event_schedule_playoff = EventSchedule(get_json(os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","eventschedule_playoff.json")))
 
 
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"), "rb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsNeigh.pkl"), "rb") as f:
         gsNeigh = pickle.load(f)
     
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"),"rb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsSVC.pkl"),"rb") as f:
         gsSVC = pickle.load(f)
     
     predictors = [gsNeigh, gsSVC]
@@ -473,7 +473,7 @@ def push_teams(service):
         print(info_i()+"    Writing season-long OPR data")
         
     write_to_range = TEAMS_WRITE_RANGE
-    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_result_sorted.csv"))
+    data_to_push   = get_team_data(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_result_sorted.csv"))
     
     # Add the timestamp to the begining of the data
     data_to_push = add_timestamp(data_to_push.values.tolist())
@@ -495,7 +495,7 @@ def push_teams(service):
         print(info_i()+"    Writing event OPR data")
         
     write_to_range = TEAMS_EVENT_WRITE_RANGE
-    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_event_result_sorted.csv"))
+    data_to_push   = get_team_data(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_event_result_sorted.csv"))
     # Add the timestamp to the begining of the data
     data_to_push = add_timestamp(data_to_push.values.tolist())
 
@@ -522,7 +522,7 @@ def push_teams(service):
         print(info_i()+"    Writing recent OPR  data")
         
     write_to_range = TEAMS_RECENT_WRITE_RANGE
-    data_to_push   = get_team_data(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","opr","opr_recent_result_sorted.csv"))
+    data_to_push   = get_team_data(os.path.join(PROJECT_PATH,"app","generatedfiles","opr","opr_recent_result_sorted.csv"))
     # Add the timestamp to the begining of the data
     data_to_push = add_timestamp(data_to_push.values.tolist())
 
@@ -554,9 +554,9 @@ def push_rankings(service):
         print(info_i()+" [sheetsapi.py] Pushing rankings data to sheets")
     if DEBUG_LEVEL>1:
         print(info_i()+"    Uses:")
-        print(info_i()+"      -",os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.json"))
+        print(info_i()+"      -",os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_rankings.json"))
         print(info_i()+"    Creates:")
-        print(info_i()+"      -",os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv"))
+        print(info_i()+"      -",os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_rankings.csv"))
         
     #
     # Write event ranking data
@@ -566,7 +566,7 @@ def push_rankings(service):
         
     # from jsonparse, save the rankings dataframe as a csv
     try:
-        rankings_dataframe(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.json"),os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv"))
+        rankings_dataframe(os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_rankings.json"),os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_rankings.csv"))
 
     except IndexError as e:
         log_error(f"[sheetsapi.py][push_rankings] IndexError with rankngs_dataframe in jsonparse. This indicates that eventdata/event_rankings.json is either empty or malformed. This is normal if the event hasn\'t started yet. full error msg: {e}")
@@ -575,7 +575,7 @@ def push_rankings(service):
     write_to_range = TEAMS_RANKING_WRITE_RANGE
     
     try:
-        data_to_push   = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv"))
+        data_to_push   = pd.read_csv(os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_rankings.csv"))
         # Dropping multiple columns with help from 
         # https://stackoverflow.com/questions/13411544/delete-a-column-from-a-pandas-dataframe
         data_to_push.drop(
@@ -589,7 +589,7 @@ def push_rankings(service):
 
     except pd.errors.EmptyDataError:
         # if the file is empty
-        data_to_push = [["No rankings for the given event"],[f'({os.path.join(PATH_TO_FTCAPI,"app","generatedfiles","eventdata","event_rankings.csv")} is empty)']]
+        data_to_push = [["No rankings for the given event"],[f'({os.path.join(PROJECT_PATH,"app","generatedfiles","eventdata","event_rankings.csv")} is empty)']]
         log_error("[sheetsapi.py][push_rankings] generatedfiles/eventdata/event_rankings.csv is empty. This is normal if an event hasn\'t started yet, but is bad if the rankings are out.",level="Warn")
     
     
@@ -654,10 +654,10 @@ def push_elims_predictions(service):
     if DEBUG_LEVEL>1:
         print(info_i()+" [sheetsapi.py][push_elims_predictions] Elims matches data recieved. Now loading models.")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"), "rb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsNeigh.pkl"), "rb") as f:
         gsNeigh = pickle.load(f)
     
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"),"rb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsSVC.pkl"),"rb") as f:
         gsSVC = pickle.load(f)
     
     predictors = [gsNeigh, gsSVC]

--- a/app/train_algorithm.py
+++ b/app/train_algorithm.py
@@ -65,7 +65,7 @@ import os
 starttime = time.time()
 
 print("  - commonresources.py")
-from common_resources import PATH_TO_FTCAPI, PATH_TO_JOBLIB_CACHE, LATEST_VERSION, green_check, red_x, info_i, seconds_to_time
+from common_resources import PROJECT_PATH, PATH_TO_JOBLIB_CACHE, LATEST_VERSION, green_check, red_x, info_i, seconds_to_time
 print("                 Using version "+str(LATEST_VERSION))
 
 print("  - External modules:")
@@ -147,7 +147,7 @@ def describe_model(model, X_cat_test, Y_cat_test):
 print(info_i()+" Loading data...")
 
 
-pandasdata = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","machine_file.csv"), dtype={
+pandasdata = pd.read_csv(os.path.join(PROJECT_PATH,"app","machine_file.csv"), dtype={
     "RedOPR" :np.longdouble, "RedAutoOPR" :np.longdouble, "RedCCWM" :np.longdouble, 
     "blueOPR":np.longdouble, "blueAutoOPR":np.longdouble, "blueCCWM":np.longdouble, 
     "recentRedOPR" :np.longdouble, "recentRedAutoOPR" :np.longdouble, "recentRedCCWM" :np.longdouble, 
@@ -318,12 +318,12 @@ print(green_check()+" gsSVC and gsNeigh created as GridSearchCVs")
 if LOAD_MODEL:
     print(info_i()+" Loading models...")
     
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"), "rb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsNeigh.pkl"), "rb") as f:
         gsNeigh = pickle.load(f)
     
     print(green_check()+"     Model gsNeigh loaded.")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"), "rb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsSVC.pkl"), "rb") as f:
         gsSVC = pickle.load(f)
     
     print(green_check()+"     Model gsSVC loaded.")
@@ -336,10 +336,10 @@ else:
 
     print(green_check()+" gsNeigh successfully fit!")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"),"wb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsNeigh.pkl"),"wb") as f:
         pickle.dump(gsNeigh,f)
     
-    print(green_check()+" gsNeigh model saved as "+os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"))
+    print(green_check()+" gsNeigh model saved as "+os.path.join(PROJECT_PATH,"app","gsNeigh.pkl"))
 
     print(info_i()+" gsNeigh:")
     describe_model(gsNeigh, X_cat_test, Y_cat_test)
@@ -350,10 +350,10 @@ else:
     gsSVC.fit(X_cat_train, Y_cat_train)
     print(green_check()+" gsSVC successfully fit!")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"),"wb") as f:
+    with open(os.path.join(PROJECT_PATH,"app","gsSVC.pkl"),"wb") as f:
         pickle.dump(gsSVC,f)
     
-    print(green_check()+" gsSVC model saved as "+os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"))
+    print(green_check()+" gsSVC model saved as "+os.path.join(PROJECT_PATH,"app","gsSVC.pkl"))
     print("\n"+info_i()+"gsSVC")
     describe_model(gsSVC, X_cat_test, Y_cat_test)
     print(info_i()+f" That took {seconds_to_time((time.time()-starttime))} total so far")

--- a/app/train_algorithm.py
+++ b/app/train_algorithm.py
@@ -147,7 +147,7 @@ def describe_model(model, X_cat_test, Y_cat_test):
 print(info_i()+" Loading data...")
 
 
-pandasdata = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"machine_file.csv"), dtype={
+pandasdata = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"app","machine_file.csv"), dtype={
     "RedOPR" :np.longdouble, "RedAutoOPR" :np.longdouble, "RedCCWM" :np.longdouble, 
     "blueOPR":np.longdouble, "blueAutoOPR":np.longdouble, "blueCCWM":np.longdouble, 
     "recentRedOPR" :np.longdouble, "recentRedAutoOPR" :np.longdouble, "recentRedCCWM" :np.longdouble, 
@@ -318,12 +318,12 @@ print(green_check()+" gsSVC and gsNeigh created as GridSearchCVs")
 if LOAD_MODEL:
     print(info_i()+" Loading models...")
     
-    with open(os.path.join(PATH_TO_FTCAPI,"gsNeigh.pkl"), "rb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"), "rb") as f:
         gsNeigh = pickle.load(f)
     
     print(green_check()+"     Model gsNeigh loaded.")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"gsSVC.pkl"), "rb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"), "rb") as f:
         gsSVC = pickle.load(f)
     
     print(green_check()+"     Model gsSVC loaded.")
@@ -336,10 +336,10 @@ else:
 
     print(green_check()+" gsNeigh successfully fit!")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"gsNeigh.pkl"),"wb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"),"wb") as f:
         pickle.dump(gsNeigh,f)
     
-    print(green_check()+" gsNeigh model saved as "+os.path.join(PATH_TO_FTCAPI,"gsNeigh.pkl"))
+    print(green_check()+" gsNeigh model saved as "+os.path.join(PATH_TO_FTCAPI,"app","gsNeigh.pkl"))
 
     print(info_i()+" gsNeigh:")
     describe_model(gsNeigh, X_cat_test, Y_cat_test)
@@ -350,10 +350,10 @@ else:
     gsSVC.fit(X_cat_train, Y_cat_train)
     print(green_check()+" gsSVC successfully fit!")
 
-    with open(os.path.join(PATH_TO_FTCAPI,"gsSVC.pkl"),"wb") as f:
+    with open(os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"),"wb") as f:
         pickle.dump(gsSVC,f)
     
-    print(green_check()+" gsSVC model saved as "+os.path.join(PATH_TO_FTCAPI,"gsSVC.pkl"))
+    print(green_check()+" gsSVC model saved as "+os.path.join(PATH_TO_FTCAPI,"app","gsSVC.pkl"))
     print("\n"+info_i()+"gsSVC")
     describe_model(gsSVC, X_cat_test, Y_cat_test)
     print(info_i()+f" That took {seconds_to_time((time.time()-starttime))} total so far")

--- a/app/view_data.py
+++ b/app/view_data.py
@@ -44,7 +44,7 @@ for matplotlib plotting
 """
 
 
-from common_resources import PATH_TO_FTCAPI, red_x, info_i, green_check, get_json
+from common_resources import PROJECT_PATH, red_x, info_i, green_check, get_json
 
 
 print(info_i()+" [viewdata.py] Importing")
@@ -82,7 +82,7 @@ def using_hist2d(ax, x, y, bins=(50, 50)):
 if do_first_map:
     print(info_i()+" Generating data")
     # Generate Data
-    allmatches = pd.read_csv(os.path.join(PATH_TO_FTCAPI,"generatedfiles","all_matches.csv"))
+    allmatches = pd.read_csv(os.path.join(PROJECT_PATH,"generatedfiles","all_matches.csv"))
     
     allmatches.drop(
                 ["description"], 
@@ -143,9 +143,9 @@ if do_first_map:
 
 print(info_i()+" Generating data")
 # Generate Data
-#allmatches = pd.read_csv(PATH_TO_FTCAPI+"globaloprs/OPR_result_sorted.json")
+#allmatches = pd.read_csv(PROJECT_PATH+"globaloprs/OPR_result_sorted.json")
 #{"teamNumber":25218, "teamName":"Undefined", "OPR":172.40222517085803, "AutoOPR":56.822136784937285, "CCWM":109.1174444069353}, 
-rj = get_json(os.path.join(PATH_TO_FTCAPI,"globaloprs","OPR_result_sorted.json"))
+rj = get_json(os.path.join(PROJECT_PATH,"globaloprs","OPR_result_sorted.json"))
 rj_dic = {"teamNumber":[],"OPR":[],"AutoOPR":[],"CCWM":[]}
 
 for team in rj["matches"]:

--- a/tests/test_common_resources.py
+++ b/tests/test_common_resources.py
@@ -63,7 +63,7 @@ class CommonResourcesTest(unittest.TestCase):
 
     def test_slashes(self):
         """ Make sure that the paths don't contain both forwardslashes and backslashes """
-        self.assertFalse(self.string_contains_both_slashes(common_resources.PATH_TO_FTCAPI))
+        self.assertFalse(self.string_contains_both_slashes(common_resources.PROJECT_PATH))
         self.assertFalse(self.string_contains_both_slashes(common_resources.PATH_TO_JOBLIB_CACHE))
     
     def test_byte_to_gb(self):


### PR DESCRIPTION
Branch 33 (for issue #33) changes `PATH_TO_FTCAPI` to `PROJECT_PATH` and removes the `/app` part of the variable.
Branch 29 (for issue #29, branched from branch 30 for issue #30) separates global calcs by year. This PR consolidates the two now instead of figuring out merge conflicts on main.